### PR TITLE
Add FastAPI MCP demo service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+venv/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # mcp_demo
-mcp_demo
+
+This demo provides a simple FastAPI service that demonstrates basic MCP (Model Control Platform) functionality. Models can be registered and listed via HTTP endpoints.
+
+## Running the Service
+
+1. Create and activate a Python virtual environment:
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   pip install fastapi uvicorn pydantic
+   ```
+
+2. Start the server with:
+   ```bash
+   uvicorn mcp_service.main:app --reload
+   ```
+
+The service exposes two main endpoints:
+
+- `POST /models` – register a new model with `name`, `version`, and optional `description` fields.
+- `GET /models` – list all registered models.
+
+## MCP Features (Demo)
+
+- Register models with version information.
+- List all registered models in memory.
+
+This is a minimal demonstration and does not persist data between runs.

--- a/mcp_service/__init__.py
+++ b/mcp_service/__init__.py
@@ -1,0 +1,3 @@
+"""MCP service package."""
+
+__all__ = []

--- a/mcp_service/main.py
+++ b/mcp_service/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+from .routes import models as models_routes
+
+app = FastAPI(title="MCP Service")
+
+app.include_router(models_routes.router)

--- a/mcp_service/models/__init__.py
+++ b/mcp_service/models/__init__.py
@@ -1,0 +1,3 @@
+from .model import ModelInfo
+
+__all__ = ["ModelInfo"]

--- a/mcp_service/models/model.py
+++ b/mcp_service/models/model.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+from typing import Optional
+
+class ModelInfo(BaseModel):
+    name: str
+    version: str
+    description: Optional[str] = None

--- a/mcp_service/routes/__init__.py
+++ b/mcp_service/routes/__init__.py
@@ -1,0 +1,3 @@
+from .models import router as models_router
+
+__all__ = ["models_router"]

--- a/mcp_service/routes/models.py
+++ b/mcp_service/routes/models.py
@@ -1,0 +1,17 @@
+from typing import List
+from fastapi import APIRouter
+
+from ..models import ModelInfo
+
+router = APIRouter()
+
+models: List[ModelInfo] = []
+
+@router.post('/models', response_model=ModelInfo)
+def register_model(model: ModelInfo) -> ModelInfo:
+    models.append(model)
+    return model
+
+@router.get('/models', response_model=List[ModelInfo])
+def list_models() -> List[ModelInfo]:
+    return models


### PR DESCRIPTION
## Summary
- add `.gitignore`
- create `mcp_service` package with basic FastAPI app
- define `ModelInfo` pydantic model
- implement routes for registering and listing models
- document usage in `README`

## Testing
- `python -m compileall mcp_service`

------
https://chatgpt.com/codex/tasks/task_e_686206d0bc30832fb09d13cae56baeb2